### PR TITLE
refactor: simplify NavIcon component props and remove internal state …

### DIFF
--- a/src/once-ui/components/NavIcon.tsx
+++ b/src/once-ui/components/NavIcon.tsx
@@ -1,24 +1,15 @@
-'use client';
-
-import React, { useState, forwardRef } from 'react';
+import React, { forwardRef } from 'react';
 import styles from './NavIcon.module.scss';
 import { Flex } from '.';
 
 interface NavIconProps {
-    className?: string;
-    style?: React.CSSProperties;
-    onClick?: () => void;
+    className: string;
+    style: React.CSSProperties;
+    onClick: () => void;
+    isActive: boolean;
 }
 
-const NavIcon = forwardRef<HTMLDivElement, NavIconProps>(({ className, style, onClick }, ref) => {
-    const [isActive, setIsActive] = useState(false);
-
-    const handleClick = () => {
-        setIsActive(!isActive);
-        if (onClick) {
-            onClick();
-        }
-    };
+const NavIcon = forwardRef<HTMLDivElement, Partial<NavIconProps>>(({ className, isActive, style, onClick }, ref) => {
 
     return (
         <Flex
@@ -28,7 +19,7 @@ const NavIcon = forwardRef<HTMLDivElement, NavIconProps>(({ className, style, on
             position="relative"
             className={`${styles.button} ${className || ''}`}
             style={{ ...style }}
-            onClick={handleClick}>
+            onClick={onClick}>
             <div className={`${styles.line} ${isActive ? `${styles.active}` : ''}`} />
             <div className={`${styles.line} ${isActive ? `${styles.active}` : ''}`} />
         </Flex>

--- a/src/once-ui/components/NavIcon.tsx
+++ b/src/once-ui/components/NavIcon.tsx
@@ -1,15 +1,21 @@
 import React, { forwardRef } from 'react';
 import styles from './NavIcon.module.scss';
 import { Flex } from '.';
+import classNames from 'classnames';
 
 interface NavIconProps {
-    className: string;
-    style: React.CSSProperties;
-    onClick: () => void;
+    className?: string;
+    style?: React.CSSProperties;
+    onClick?: () => void;
     isActive: boolean;
 }
 
-const NavIcon = forwardRef<HTMLDivElement, Partial<NavIconProps>>(({ className, isActive, style, onClick }, ref) => {
+const NavIcon = forwardRef<HTMLDivElement, Partial<NavIconProps>>(({
+    className,
+    isActive,
+    style,
+    onClick
+}, ref) => {
 
     return (
         <Flex
@@ -17,11 +23,11 @@ const NavIcon = forwardRef<HTMLDivElement, Partial<NavIconProps>>(({ className, 
             tabIndex={0}
             radius="m"
             position="relative"
-            className={`${styles.button} ${className || ''}`}
+            className={classNames(styles.button, className || '')}
             style={{ ...style }}
             onClick={onClick}>
-            <div className={`${styles.line} ${isActive ? `${styles.active}` : ''}`} />
-            <div className={`${styles.line} ${isActive ? `${styles.active}` : ''}`} />
+            <div className={classNames(styles.line, isActive && styles.active)} />
+            <div className={classNames(styles.line, isActive && styles.active)} />
         </Flex>
     );
 });


### PR DESCRIPTION
This pull request includes changes to the `src/once-ui/components/NavIcon.tsx` file to simplify the component and improve its functionality. The most important changes involve removing unnecessary state management and updating the `NavIconProps` interface.

This one is done due to if we use the NavIcon and navigate to some component than the state is not changing for that again we need to use some expensive operations like the `useEffect` with some conditions, so it's better to handle the events and state from the parent component and pass through by the `props`, so we not gonna have this effect and it'll work significantly 

Simplification of `NavIcon` component:

* Removed the `useState` hook and the `handleClick` function, relying instead on the `isActive` prop to manage the active state.
* Updated the `NavIconProps` interface to make `className`, `style`, and `onClick` required properties, and added a new `isActive` property.

Code cleanup:

* Removed the `'use client'` directive and unnecessary imports to clean up the code.
* Simplified the `onClick` handler in the `Flex` component by directly using the `onClick` prop.