### PR TITLE
feat: add BentoGrid component with responsive grid layout and styles

### DIFF
--- a/src/once-ui/components/BentoGrid.module.scss
+++ b/src/once-ui/components/BentoGrid.module.scss
@@ -1,29 +1,70 @@
 .bentoGrid {
-    display: grid;
+  display: grid;
+  grid-gap: var(--static-space-24);
+  padding: var(--static-space-24);
+  animation: fadeIn var(--transition-duration-micro-medium)
+    var(--transition-eased);
+  background-color: var(--background-surface);
+}
+
+.gridItem {
+  background-color: var(--surface-background);
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius-m);
+  overflow: hidden;
+  transition: transform 0.2s ease-in-out;
+  padding: var(--static-space-16);
+
+  &:hover {
+    transform: scale(1.02);
+  }
+}
+
+.gap-xs {
+    grid-gap: var(--static-space-4);
+  }
+  
+  .gap-s {
+    grid-gap: var(--static-space-12);
+  }
+  
+  .gap-m {
     grid-gap: var(--static-space-24);
+  }
+  
+  .gap-l {
+    grid-gap: var(--static-space-48);
+  }
+  
+  .gap-xl {
+    grid-gap: var(--static-space-64);
+  }
+  
+  /* Padding Sizes */
+  .padding-xs {
+    padding: var(--static-space-4);
+  }
+  
+  .padding-s {
+    padding: var(--static-space-12);
+  }
+  
+  .padding-m {
     padding: var(--static-space-24);
-    animation: fadeIn var(--transition-duration-micro-medium)
-      var(--transition-eased);
-    background-color: var(--background-surface);
   }
   
-  .gridItem {
-    background-color: var(--surface-background);
-    border: 1px solid var(--surface-border);
-    border-radius: var(--radius-m);
-    overflow: hidden;
-    transition: transform 0.2s ease-in-out;
-    padding: var(--static-space-16);
-  
-    &:hover {
-      transform: scale(1.02);
-    }
+  .padding-l {
+    padding: var(--static-space-48);
   }
   
-  /* Responsive Adjustments */
-  @media (max-width: 768px) {
-    .bentoGrid {
-      grid-template-columns: repeat(1, 1fr);
-    }
+  .padding-xl {
+    padding: var(--static-space-64);
   }
   
+
+/* Responsive Adjustments */
+@media (max-width: 768px) {
+  .bentoGrid {
+    grid-template-columns: repeat(1, 1fr);
+  }
+}

--- a/src/once-ui/components/BentoGrid.module.scss
+++ b/src/once-ui/components/BentoGrid.module.scss
@@ -21,50 +21,49 @@
 }
 
 .gap-xs {
-    grid-gap: var(--static-space-4);
-  }
-  
-  .gap-s {
-    grid-gap: var(--static-space-12);
-  }
-  
-  .gap-m {
-    grid-gap: var(--static-space-24);
-  }
-  
-  .gap-l {
-    grid-gap: var(--static-space-48);
-  }
-  
-  .gap-xl {
-    grid-gap: var(--static-space-64);
-  }
-  
-  /* Padding Sizes */
-  .padding-xs {
-    padding: var(--static-space-4);
-  }
-  
-  .padding-s {
-    padding: var(--static-space-12);
-  }
-  
-  .padding-m {
-    padding: var(--static-space-24);
-  }
-  
-  .padding-l {
-    padding: var(--static-space-48);
-  }
-  
-  .padding-xl {
-    padding: var(--static-space-64);
-  }
-  
+  gap: var(--static-space-4);
+}
+
+.gap-s {
+  gap: var(--static-space-12);
+}
+
+.gap-m {
+  gap: var(--static-space-24);
+}
+
+.gap-l {
+  gap: var(--static-space-48);
+}
+
+.gap-xl {
+  gap: var(--static-space-64);
+}
+
+/* Padding Sizes */
+.padding-xs {
+  padding: var(--static-space-4);
+}
+
+.padding-s {
+  padding: var(--static-space-12);
+}
+
+.padding-m {
+  padding: var(--static-space-24);
+}
+
+.padding-l {
+  padding: var(--static-space-48);
+}
+
+.padding-xl {
+  padding: var(--static-space-64);
+}
 
 /* Responsive Adjustments */
 @media (max-width: 768px) {
   .bentoGrid {
-    grid-template-columns: repeat(1, 1fr);
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
   }
 }

--- a/src/once-ui/components/BentoGrid.module.scss
+++ b/src/once-ui/components/BentoGrid.module.scss
@@ -1,0 +1,29 @@
+.bentoGrid {
+    display: grid;
+    grid-gap: var(--static-space-24);
+    padding: var(--static-space-24);
+    animation: fadeIn var(--transition-duration-micro-medium)
+      var(--transition-eased);
+    background-color: var(--background-surface);
+  }
+  
+  .gridItem {
+    background-color: var(--surface-background);
+    border: 1px solid var(--surface-border);
+    border-radius: var(--radius-m);
+    overflow: hidden;
+    transition: transform 0.2s ease-in-out;
+    padding: var(--static-space-16);
+  
+    &:hover {
+      transform: scale(1.02);
+    }
+  }
+  
+  /* Responsive Adjustments */
+  @media (max-width: 768px) {
+    .bentoGrid {
+      grid-template-columns: repeat(1, 1fr);
+    }
+  }
+  

--- a/src/once-ui/components/BentoGrid.tsx
+++ b/src/once-ui/components/BentoGrid.tsx
@@ -1,0 +1,67 @@
+import React, { ReactNode, forwardRef } from "react";
+import classNames from "classnames";
+import { GridProps } from "./Grid";
+import styles from "./BentoGrid.module.scss";
+import { Flex } from "./Flex";
+
+interface BentoGridProps extends GridProps {
+  layout: GridLayout[];
+  children: ReactNode[];
+}
+
+interface GridLayout {
+  area?: string;
+  columnSpan?: number;
+  rowSpan?: number;
+}
+
+const BentoGrid = forwardRef<HTMLDivElement, BentoGridProps>(
+  ({ layout, children, className, style, ...rest }, ref) => {
+    const combinedStyle = {
+      ...style,
+      display: "grid",
+      gridGap: "var(--static-space-24)",
+      padding: "var(--static-space-24)",
+      animation:
+        "fadeIn var(--transition-duration-micro-medium) var(--transition-eased)",
+      backgroundColor: "var(--background-surface)",
+    };
+
+    return (
+      <Flex
+        ref={ref}
+        className={classNames(styles.bentoGrid, className)}
+        style={combinedStyle}
+        {...rest}
+      >
+        {children.map((child, index) => {
+          const itemLayout = layout[index] || {};
+          const gridStyle: React.CSSProperties = {
+            gridColumn: itemLayout.columnSpan
+              ? `span ${itemLayout.columnSpan}`
+              : undefined,
+            gridRow: itemLayout.rowSpan
+              ? `span ${itemLayout.rowSpan}`
+              : undefined,
+          };
+
+          return (
+            <Flex
+              flex={1}
+              key={index}
+              className={classNames(styles.gridItem)}
+              style={gridStyle}
+            >
+              {child}
+            </Flex>
+          );
+        })}
+      </Flex>
+    );
+  },
+);
+
+BentoGrid.displayName = "BentoGrid";
+
+export { BentoGrid };
+export type { BentoGridProps, GridLayout };

--- a/src/once-ui/components/BentoGrid.tsx
+++ b/src/once-ui/components/BentoGrid.tsx
@@ -7,6 +7,8 @@ import { Flex } from "./Flex";
 interface BentoGridProps extends GridProps {
   layout: GridLayout[];
   children: ReactNode[];
+  gap?: 'xs' | 's' | 'm' | 'l' | 'xl';
+  padding?: 'xs' | 's' | 'm' | 'l' | 'xl';
 }
 
 interface GridLayout {
@@ -16,12 +18,16 @@ interface GridLayout {
 }
 
 const BentoGrid = forwardRef<HTMLDivElement, BentoGridProps>(
-  ({ layout, children, className, style, ...rest }, ref) => {
+  ({ layout, children, className, style, gap = 'm', padding = 'm', ...rest }, ref) => {
+    const combinedClassName = classNames(
+      styles.bentoGrid,
+      styles[`gap-${gap}`],
+      styles[`padding-${padding}`],
+      className
+    );
+
     const combinedStyle = {
       ...style,
-      display: "grid",
-      gridGap: "var(--static-space-24)",
-      padding: "var(--static-space-24)",
       animation:
         "fadeIn var(--transition-duration-micro-medium) var(--transition-eased)",
       backgroundColor: "var(--background-surface)",
@@ -30,7 +36,7 @@ const BentoGrid = forwardRef<HTMLDivElement, BentoGridProps>(
     return (
       <Flex
         ref={ref}
-        className={classNames(styles.bentoGrid, className)}
+        className={combinedClassName}
         style={combinedStyle}
         {...rest}
       >
@@ -39,10 +45,10 @@ const BentoGrid = forwardRef<HTMLDivElement, BentoGridProps>(
           const gridStyle: React.CSSProperties = {
             gridColumn: itemLayout.columnSpan
               ? `span ${itemLayout.columnSpan}`
-              : undefined,
+              : "span 1",
             gridRow: itemLayout.rowSpan
               ? `span ${itemLayout.rowSpan}`
-              : undefined,
+              : "span 1",
           };
 
           return (

--- a/src/once-ui/components/BentoGrid.tsx
+++ b/src/once-ui/components/BentoGrid.tsx
@@ -2,7 +2,6 @@ import React, { ReactNode, forwardRef } from "react";
 import classNames from "classnames";
 import { GridProps } from "./Grid";
 import styles from "./BentoGrid.module.scss";
-import { Flex } from "./Flex";
 
 interface BentoGridProps extends GridProps {
   layout: GridLayout[];
@@ -12,7 +11,6 @@ interface BentoGridProps extends GridProps {
 }
 
 interface GridLayout {
-  area?: string;
   columnSpan?: number;
   rowSpan?: number;
 }
@@ -34,7 +32,7 @@ const BentoGrid = forwardRef<HTMLDivElement, BentoGridProps>(
     };
 
     return (
-      <Flex
+      <div
         ref={ref}
         className={combinedClassName}
         style={combinedStyle}
@@ -52,17 +50,16 @@ const BentoGrid = forwardRef<HTMLDivElement, BentoGridProps>(
           };
 
           return (
-            <Flex
-              flex={1}
+            <div
               key={index}
               className={classNames(styles.gridItem)}
               style={gridStyle}
             >
               {child}
-            </Flex>
+            </div>
           );
         })}
-      </Flex>
+      </div>
     );
   },
 );

--- a/src/once-ui/components/index.ts
+++ b/src/once-ui/components/index.ts
@@ -20,6 +20,7 @@ export type { DropdownOptions } from './Dropdown';
 export { DropdownWrapper } from './DropdownWrapper';
 export { Grid } from './Grid';
 export type { GridProps } from './Grid';
+export { BentoGrid } from "./BentoGrid";
 export { Feedback } from './Feedback';
 export { Flex } from './Flex';
 export { GlitchFx } from './GlitchFx';


### PR DESCRIPTION
This pull request introduces a new `BentoGrid` component to the `once-ui` library. The changes include the implementation of the component in TypeScript, the corresponding styles in SCSS, and updates to the component exports.

### New Component Addition:

* [`src/once-ui/components/BentoGrid.tsx`](diffhunk://#diff-f2c8f8d2bfb180a77784b3a5bc169e522d50205069d619e24d5caf5b509a42a1R1-R67): Added the `BentoGrid` component, which uses a easily changeable grid layout to arrange its children. The component supports custom grid layouts through the `GridLayout` interface and applies various styles and animations.
* [`src/once-ui/components/BentoGrid.module.scss`](diffhunk://#diff-6e55f0b93486a0fd7bdc266572d117fb578f90524265e85abcf81d77eb7ed926R1-R29): Added styles for the `BentoGrid` component, including grid layout properties, item styling, hover effects, and responsive adjustments for smaller screens.

### Export Updates:

* [`src/once-ui/components/index.ts`](diffhunk://#diff-a1e7e7aeadc2a1975acfddc795650c60e338266e4d4fded9ac700108ddbf2e82R23): Updated the exports to include the new `BentoGrid` component.

## Usage

Use <BentoGrid> with nested flex components.

Ex:
```bash
          <BentoGrid layout={layout}>
            <Flex width="xs" height="xs" paddingX="4">
            </Flex>
            <Flex width="xs" fillHeight direction="column" paddingX="s">
            </Flex>
            <Flex fillWidth alignItems="right" direction="column" paddingY="8">
            </Flex>
            <Flex width="xs" height="xs" paddingX="4">
            </Flex>
            <Flex width="xs" paddingX="4">
            </Flex>
            <Flex width={82} height="xs" direction="column" gap="8" padding="8">
            </Flex>
          </BentoGrid>
```

## The layout prop

Used to set dynamic layout of grid

```bash
  const layout = [
    { columnSpan: 4, rowSpan: 1 }, // Large item spanning 4 columns and 1 rows
    { columnSpan: 1, rowSpan: 2 }, // Medium item spanning 1 column and 2 rows
    { columnSpan: 2, rowSpan: 1 }, // Wide item spanning 2 columns
    { columnSpan: 3, rowSpan: 1 }, // Spans 3 columns and 1 row
    { columnSpan: 1, rowSpan: 1 }, // Regular item
    { columnSpan: 2, rowSpan: 1 }, // Spans 2 columns and 1 row
  ];
```

Results from those code snippets:
![image](https://github.com/user-attachments/assets/d480c66d-9415-4788-977f-5aef8feff03e)


### Examples:


Current example from [Pyupil](https://pyupil.me) using those code snippets
![image](https://github.com/user-attachments/assets/b9206d71-a4d9-48ff-af41-fa6a6bd22540)

Older Pyupil example, Link: [Older Pyupil Website](https://pyupil-ncmj4qlai-critikal.vercel.app/)

![image](https://github.com/user-attachments/assets/27595609-b449-4b8e-9646-b67e5a0e5b4e)

### Additional Examples:

(sorry i was too lazy to fix spacing inside each box i just altered the layout prop)
![image](https://github.com/user-attachments/assets/2411db2f-b3c9-44ec-94a0-cdbedfb8c682)

![image](https://github.com/user-attachments/assets/b460c24a-d7ea-4275-b8ef-ce9e715f4d52)

![image](https://github.com/user-attachments/assets/83831143-9e04-45a9-83fb-ee1055b5a713)

