### PR TITLE
feat: add ThreeDTiltFx component with 3D tilt effect and styling

### DIFF
--- a/src/once-ui/components/ThreeDTiltFx.module.scss
+++ b/src/once-ui/components/ThreeDTiltFx.module.scss
@@ -1,0 +1,6 @@
+.tiltFX {
+    transform-style: preserve-3d;
+    display: inline-block; /* Ensures the transform affects the element correctly */
+    backface-visibility: hidden; /* Optional: Improves performance */
+    /* Added any additional styles you need */
+  }

--- a/src/once-ui/components/ThreeDTiltFx.tsx
+++ b/src/once-ui/components/ThreeDTiltFx.tsx
@@ -19,6 +19,7 @@ interface TiltProps {
   bufferZone?: number;
   edgeThreshold?: number;
   maxVelocity?: number;
+  scale?: number;
 }
 
 interface TiltFXProps {
@@ -30,6 +31,7 @@ interface TiltFXProps {
   bufferZone?: number;
   edgeThreshold?: number;
   maxVelocity?: number;
+  scale?: number;
   style?: CSSProperties;
   className?: string;
 }
@@ -43,11 +45,12 @@ export const ThreeDTiltFx: React.FC<TiltFXProps> = ({
   bufferZone = 0.15,
   edgeThreshold = 0.05,
   maxVelocity = 2,
+  scale = 1, // Default scale to 1
   style,
   className,
 }) => {
   const [transform, setTransform] = useState(
-    "perspective(1000px) rotateX(0deg) rotateY(0deg) scale(1)"
+    `perspective(1000px) rotateX(0deg) rotateY(0deg) scale(${scale})`
   );
 
   const targetRotation = useRef({ x: 0, y: 0 });
@@ -86,9 +89,9 @@ export const ThreeDTiltFx: React.FC<TiltFXProps> = ({
       maxTilt
     );
 
-    // Update the transform
+    // Update the transform without scaling
     setTransform(
-      `perspective(1000px) rotateX(${currentRotation.current.x}deg) rotateY(${currentRotation.current.y}deg) scale(1.05)`
+      `perspective(1000px) rotateX(${currentRotation.current.x}deg) rotateY(${currentRotation.current.y}deg) scale(${scale})`
     );
 
     // Continue the animation if not yet at the target
@@ -97,7 +100,7 @@ export const ThreeDTiltFx: React.FC<TiltFXProps> = ({
     } else {
       requestRef.current = null;
     }
-  }, [dampening, threshold, maxVelocity, maxTilt]);
+  }, [dampening, threshold, maxVelocity, maxTilt, scale]);
 
   const handleMouseMove = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {

--- a/src/once-ui/components/ThreeDTiltFx.tsx
+++ b/src/once-ui/components/ThreeDTiltFx.tsx
@@ -1,0 +1,166 @@
+// ThreeDTiltFx.tsx
+"use client";
+
+import React, {
+  ReactNode,
+  useState,
+  useCallback,
+  useRef,
+  useEffect,
+  CSSProperties,
+} from "react";
+import styles from "./ThreeDTiltFx.module.scss"; // Ensure this CSS module exists
+
+interface TiltProps {
+  maxTilt?: number;
+  dampening?: number;
+  transitionDuration?: number;
+  threshold?: number;
+  bufferZone?: number;
+  edgeThreshold?: number;
+  maxVelocity?: number;
+}
+
+interface TiltFXProps {
+  children: ReactNode;
+  maxTilt?: number;
+  dampening?: number;
+  transitionDuration?: number;
+  threshold?: number;
+  bufferZone?: number;
+  edgeThreshold?: number;
+  maxVelocity?: number;
+  style?: CSSProperties;
+  className?: string;
+}
+
+export const ThreeDTiltFx: React.FC<TiltFXProps> = ({
+  children,
+  maxTilt = 10,
+  dampening = 0.05,
+  transitionDuration = 300,
+  threshold = 0.1,
+  bufferZone = 0.15,
+  edgeThreshold = 0.05,
+  maxVelocity = 2,
+  style,
+  className,
+}) => {
+  const [transform, setTransform] = useState(
+    "perspective(1000px) rotateX(0deg) rotateY(0deg) scale(1)"
+  );
+
+  const targetRotation = useRef({ x: 0, y: 0 });
+  const currentRotation = useRef({ x: 0, y: 0 });
+  const requestRef = useRef<number | null>(null);
+
+  const clamp = (value: number, min: number, max: number) => {
+    return Math.max(min, Math.min(max, value));
+  };
+
+  const animate = useCallback(() => {
+    const { x: currentX, y: currentY } = currentRotation.current;
+    const { x: targetX, y: targetY } = targetRotation.current;
+
+    // Calculate the difference
+    let deltaX = targetX - currentX;
+    let deltaY = targetY - currentY;
+
+    // Limit the maximum delta to prevent rapid changes
+    deltaX = clamp(deltaX, -maxVelocity, maxVelocity);
+    deltaY = clamp(deltaY, -maxVelocity, maxVelocity);
+
+    // Apply dampening
+    currentRotation.current.x += deltaX * dampening;
+    currentRotation.current.y += deltaY * dampening;
+
+    // Clamp the rotation to maxTilt
+    currentRotation.current.x = clamp(
+      currentRotation.current.x,
+      -maxTilt,
+      maxTilt
+    );
+    currentRotation.current.y = clamp(
+      currentRotation.current.y,
+      -maxTilt,
+      maxTilt
+    );
+
+    // Update the transform
+    setTransform(
+      `perspective(1000px) rotateX(${currentRotation.current.x}deg) rotateY(${currentRotation.current.y}deg) scale(1.05)`
+    );
+
+    // Continue the animation if not yet at the target
+    if (Math.abs(deltaX) > threshold || Math.abs(deltaY) > threshold) {
+      requestRef.current = requestAnimationFrame(animate);
+    } else {
+      requestRef.current = null;
+    }
+  }, [dampening, threshold, maxVelocity, maxTilt]);
+
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      const element = e.currentTarget;
+      const rect = element.getBoundingClientRect();
+
+      const centerX = rect.left + rect.width / 2;
+      const centerY = rect.top + rect.height / 2;
+
+      const mouseX = e.clientX - centerX;
+      const mouseY = e.clientY - centerY;
+
+      // Normalize mouse positions and clamp them
+      const normalizedX = clamp(mouseX / (rect.width / 2), -1, 1);
+      const normalizedY = clamp(mouseY / (rect.height / 2), -1, 1);
+
+      // Calculate the target rotation
+      targetRotation.current = {
+        x: normalizedY * maxTilt,
+        y: normalizedX * maxTilt,
+      };
+
+      // Start the animation if not already started
+      if (requestRef.current === null) {
+        requestRef.current = requestAnimationFrame(animate);
+      }
+    },
+    [animate, maxTilt]
+  );
+
+  const handleMouseLeave = useCallback(() => {
+    targetRotation.current = { x: 0, y: 0 };
+
+    // Start the animation to reset rotation
+    if (requestRef.current === null) {
+      requestRef.current = requestAnimationFrame(animate);
+    }
+  }, [animate]);
+
+  useEffect(() => {
+    return () => {
+      if (requestRef.current) {
+        cancelAnimationFrame(requestRef.current);
+      }
+    };
+  }, []);
+
+  return (
+    <div
+      onMouseMove={handleMouseMove}
+      onMouseLeave={handleMouseLeave}
+      style={{
+        transform,
+        width: "100%",
+        height: "100%",
+        willChange: "transform",
+        ...style,
+      }}
+      className={`${styles.tiltFX} ${className || ""}`}
+    >
+      {children}
+    </div>
+  );
+};
+
+ThreeDTiltFx.displayName = "ThreeDTiltFx";

--- a/src/once-ui/components/index.ts
+++ b/src/once-ui/components/index.ts
@@ -1,3 +1,4 @@
+import { ThreeDTiltFx } from './ThreeDTiltFx';
 export { Accordion } from './Accordion';
 export { Arrow } from './Arrow';
 export { Avatar } from './Avatar';
@@ -58,6 +59,7 @@ export { Toast } from './Toast';
 export { Toaster } from './Toaster';
 export { ToggleButton } from './ToggleButton';
 export { Tooltip } from './Tooltip';
+export { ThreeDTiltFx } from './ThreeDTiltFx';
 export { User } from './User';
 export type { UserProps } from './User';
 export { UserMenu } from './UserMenu';


### PR DESCRIPTION
This pull request introduces a new `ThreeDTiltFx` component, which adds a 3D tilt effect to elements. The most important changes include the creation of the component, its associated styles, and its export in the component index.

New `ThreeDTiltFx` component:

* [`src/once-ui/components/ThreeDTiltFx.tsx`](diffhunk://#diff-067a65a09996dd815733b4337889c4ccfde85480962b19d1d1ab5b401f07372eR1-R166): Implemented the `ThreeDTiltFx` component, which applies a 3D tilt effect to its children based on mouse movement. The component includes customizable properties such as `maxTilt`, `dampening`, and `transitionDuration`.

Associated styles:

* [`src/once-ui/components/ThreeDTiltFx.module.scss`](diffhunk://#diff-48223529770c9ca4dc29a6bce575ae7a710c8e070da54e8b4e8341e508711b95R1-R6): Added styles for the `ThreeDTiltFx` component to ensure the 3D transform is applied correctly and improve performance.

Component export:

* [`src/once-ui/components/index.ts`](diffhunk://#diff-a1e7e7aeadc2a1975acfddc795650c60e338266e4d4fded9ac700108ddbf2e82R1): Exported the `ThreeDTiltFx` component to make it available for use in other parts of the application. [[1]](diffhunk://#diff-a1e7e7aeadc2a1975acfddc795650c60e338266e4d4fded9ac700108ddbf2e82R1) [[2]](diffhunk://#diff-a1e7e7aeadc2a1975acfddc795650c60e338266e4d4fded9ac700108ddbf2e82R62)

Demo: 


https://github.com/user-attachments/assets/baaf2029-4d44-40c6-b365-176d9f76e778



