### PR TITLE
feat: add InputOTP component for OTP input functionality

### DIFF
--- a/src/once-ui/components/InputOTP.module.scss
+++ b/src/once-ui/components/InputOTP.module.scss
@@ -1,0 +1,90 @@
+.input {
+    box-sizing: border-box;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: var(--font-size-heading-xl);
+    width: var(--static-space-64);
+    height: var(--static-space-64);
+    margin: 0 var(--static-space-8);
+    border: 1px solid var(--neutral-border-medium);
+    border-radius: var(--radius-m);
+    transition: border-color 0.2s, box-shadow 0.2s;
+  
+    &:focus-within {
+      border-color: var(--brand-border-weak);
+      box-shadow: 0 0 0 2px var(--brand-alpha-weak);
+      animation: focusAnimation 0.3s forwards;
+    }
+  
+    &:not(:focus-within):not(:placeholder-shown) {
+      animation: filledAnimation 0.3s forwards;
+    }
+  }
+  
+  .inputs {
+  
+  
+    justify-content: center;
+    padding: 0;
+    border-radius: var(--radius-l);
+    background: transparent;
+    font-size: var(--font-size-heading-xl);
+    text-align: center;
+    transition: border-color 0.2s, box-shadow 0.2s;
+    width: var(--static-space-48);
+    
+  
+    input {
+      width: 100%;
+      height: 100%;
+      border: none;
+      outline: none;
+      background: transparent;
+      font-size: inherit;
+      text-align: center;
+      line-height: var(--static-space-64);
+      padding: 0;
+    }
+  
+    &:focus-within {
+      border-color: var(--brand-border-strong);
+      box-shadow: 0 0 0 2px var(--brand-alpha-strong);
+      animation: focusAnimation 0.3s forwards;
+    }
+  
+    &:not(:focus-within):not(:placeholder-shown) {
+      animation: filledAnimation 0.3s forwards;
+    }
+  }
+  
+  @keyframes focusAnimation {
+    0% {
+      transform: scale(1);
+    }
+    50% {
+      transform: scale(1.05);
+    }
+    100% {
+      transform: scale(1);
+    }
+  }
+  
+  @keyframes filledAnimation {
+    0% {
+      background-color: var(--neutral-background-strong);
+    }
+    100% {
+    }
+  }
+  
+  .container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: var(--static-space-8);
+  
+    & > :nth-child(3) {
+      margin-right: var(--static-space-24);
+    }
+  }

--- a/src/once-ui/components/InputOTP.tsx
+++ b/src/once-ui/components/InputOTP.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import React, { useState, useRef } from "react";
+import { Flex, Input } from ".";
+import styles from "./InputOTP.module.scss";
+
+interface InputOTPProps {
+  length?: number;
+  onComplete?: (code: string) => void;
+  onError?: (message: string) => void;
+}
+
+const InputOTP: React.FC<InputOTPProps> = ({ 
+  length = 6, 
+  onComplete,
+  onError 
+}) => {
+  const [values, setValues] = useState<string[]>(Array(length).fill(""));
+  const inputsRef = useRef<Array<HTMLInputElement | null>>([]);
+
+  const handleChange = (index: number, value: string) => {
+    if (value === "" || /^[0-9]$/.test(value)) {
+      const newValues = [...values];
+      newValues[index] = value;
+      setValues(newValues);
+
+      if (value && index < length - 1) {
+        inputsRef.current[index + 1]?.focus();
+      }
+
+      if (newValues.every((val) => val !== "") && onComplete) {
+        onComplete(newValues.join(""));
+      }
+    } else {
+      onError?.("Please enter numbers only.");
+    }
+  };
+
+  const handleKeyDown = (
+    index: number,
+    event: React.KeyboardEvent<HTMLInputElement>,
+  ) => {
+    if (event.key === "Backspace") {
+      if (values[index]) {
+        setValues((prevValues) => {
+          const newValues = [...prevValues];
+          newValues[index] = "";
+          return newValues;
+        });
+      } else if (index > 0) {
+        inputsRef.current[index - 1]?.focus();
+      }
+    }
+  };
+
+  return (
+    <Flex gap="8" justifyContent="center" className={styles.container}>
+      {Array.from({ length }, (_, index) => (
+        <Input
+          key={index}
+          ref={(el) => {
+            inputsRef.current[index] = el;
+          }}
+          id={`otp-${index}`}
+          label=" "
+          labelAsPlaceholder
+          type="text"
+          inputMode="numeric"
+          maxLength={1}
+          value={values[index]}
+          onChange={(e) => handleChange(index, e.target.value)}
+          onKeyDown={(e) => handleKeyDown(index, e)}
+          className={styles.inputs}
+        />
+      ))}
+    </Flex>
+  );
+};
+
+export { InputOTP };
+export type { InputOTPProps };

--- a/src/once-ui/components/index.ts
+++ b/src/once-ui/components/index.ts
@@ -1,4 +1,5 @@
 export { Accordion } from './Accordion';
+export { InputOTP } from './InputOTP';
 export { Arrow } from './Arrow';
 export { Avatar } from './Avatar';
 export type { AvatarProps } from './Avatar';


### PR DESCRIPTION
This pull request introduces a new `InputOTP` component, along with its associated styles, to the `once-ui` library. The most important changes include adding the `InputOTP` component, defining its styles, and updating the component exports.

New `InputOTP` component:

* [`src/once-ui/components/InputOTP.tsx`](diffhunk://#diff-c81c79eb07d2f0b43d14e3c8b597034c2639a56a06ee109c22adeb00d1970666R1-R81): Added the `InputOTP` component, which allows users to input a one-time password (OTP) with validation and focus management.

Styling for `InputOTP`:

* [`src/once-ui/components/InputOTP.module.scss`](diffhunk://#diff-4147949ebf5a8234b17dc2ad79d962cd7dd322660b1f1e97a7643fdec4b0a3eaR1-R90): Added styles for the `InputOTP` component, including focus and filled animations, and layout adjustments.

Component export updates:

* [`src/once-ui/components/index.ts`](diffhunk://#diff-a1e7e7aeadc2a1975acfddc795650c60e338266e4d4fded9ac700108ddbf2e82R2): Exported the new `InputOTP` component for use in other parts of the application.

Prop OnComplete and OnError integrates with Toaster

Ex.

```bash
 const [toasts, setToasts] = useState<Toast[]>([]);
  const removeToast = (id: string) => {
    setToasts((prev) => prev.filter((toast) => toast.id !== id));
  };

  const addToast = (message: string, variant: "success" | "danger") => {
    const newToast = {
      id: uuidv4(),
      message,
      variant,
    };
    setToasts((prev) => [...prev, newToast]);
  };
```
```bash
<Toaster toasts={toasts} removeToast={removeToast} />
```
```bash
<InputOTP
        onComplete={(code) => {
          console.log("Complete:", code);
          addToast("OTP verified successfully!", "success");
        }}
        onError={(message) => {
          addToast(message, "danger");
        }}
      />
```
### Demo
Note that the card below the InputOTP is not part of the design but now that i think idea it may look better lol
https://github.com/user-attachments/assets/422a499c-010d-404b-b801-e80b7191e2f4

