### PR TITLE
Fix: Align login Heading in mobile screen

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -333,7 +333,7 @@ export default function Home() {
                   }}
                 />
                 <Logo wordmark={false} size="l" />
-                <Heading as="h3" variant="display-default-s">
+                <Heading as="h3" variant="display-default-s" align="center">
                   Welcome to Once UI
                 </Heading>
                 <Text onBackground="neutral-medium" marginBottom="24">


### PR DESCRIPTION
Was just trying out the starter template, and encountered a small ui bug.