### PR TITLE
Allows the dialog title prop to accept a custom ReactNode

### DIFF
--- a/src/once-ui/components/Dialog.tsx
+++ b/src/once-ui/components/Dialog.tsx
@@ -17,7 +17,7 @@ import styles from "./Dialog.module.scss";
 interface DialogProps extends Omit<React.ComponentProps<typeof Flex>, "title"> {
   isOpen: boolean;
   onClose: () => void;
-  title: ReactNode;
+  title: ReactNode | string;
   description?: ReactNode;
   children: ReactNode;
   footer?: ReactNode;
@@ -283,9 +283,13 @@ const Dialog: React.FC<DialogProps> = forwardRef<HTMLDivElement, DialogProps>(
               gap="4"
             >
               <Flex fillWidth horizontal="space-between" gap="8">
-                <Heading id="dialog-title" variant="heading-strong-l">
-                  {title}
-                </Heading>
+                {typeof title === 'string' ? (
+                  <Heading id="dialog-title" variant="heading-strong-l">
+                    {title}
+                  </Heading>
+                ) : (
+                  title
+                )}
                 <IconButton
                   icon="close"
                   size="m"


### PR DESCRIPTION
I wanted a way to increase the size of the `title` and add additional elements, like icons. I'm suggesting an update to the dialog component's `title` prop to continue rendering the string passed into the title prop as it does today, but to also extend it so that a fully custom react node can be passed in as well.

```tsx
<Dialog
  isOpen={isOpen}
  onClose={closeDialog}
  description="Let's talk about your project"
  title={
    <Row gap="16" center paddingBottom="4">
      <Icon size="m" name="calendar" />
      <Heading variant="display-default-s">
        Schedule an intro call
      </Heading>
    </Row>
  }
>
{/* Whatever else you want to put in here */}
</Dialog>
```

<img width="747" alt="CleanShot 2025-03-13 at 15 34 44@2x" src="https://github.com/user-attachments/assets/156e370f-b57b-43ce-97f6-3b41d44d0838" />
