### PR TITLE
feat(icon-library): improve type safety for icons

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -50,7 +50,11 @@ export default function Home() {
   const [intro, setIntro] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-  const [tags, setTags] = useState<string[]>(["UX / UI", "Design systems", "AI / ML"]);
+  const [tags, setTags] = useState<string[]>([
+    "UX / UI",
+    "Design systems",
+    "AI / ML",
+  ]);
   const [twoFA, setTwoFA] = useState(false);
 
   const handleSelect = (value: string) => {
@@ -140,7 +144,12 @@ export default function Home() {
               variant="tertiary"
             />
             <Row position="fixed" top="20" right="20">
-              <StyleOverlay position="fixed" top="8" right="8" style={{height: "calc(100vh - var(--static-space-16))"}} />
+              <StyleOverlay
+                position="fixed"
+                top="8"
+                right="8"
+                style={{ height: "calc(100vh - var(--static-space-16))" }}
+              />
             </Row>
           </Row>
           <Row gap="16" show="s" horizontal="center" paddingRight="24">
@@ -155,7 +164,12 @@ export default function Home() {
               variant="tertiary"
             />
             <Row position="fixed" top="20" right="20">
-              <StyleOverlay position="fixed" top="8" right="8" style={{height: "calc(100vh - var(--static-space-16))"}} />
+              <StyleOverlay
+                position="fixed"
+                top="8"
+                right="8"
+                style={{ height: "calc(100vh - var(--static-space-16))" }}
+              />
             </Row>
           </Row>
         </Row>
@@ -228,14 +242,25 @@ export default function Home() {
               colorEnd: "static-transparent",
             }}
           />
-          <Column fillWidth horizontal="center" gap="32" padding="32" position="relative">
+          <Column
+            fillWidth
+            horizontal="center"
+            gap="32"
+            padding="32"
+            position="relative"
+          >
             <InlineCode radius="xl" shadow="m" fit paddingX="16" paddingY="8">
               Start by editing
               <Text onBackground="brand-medium" marginLeft="8">
                 app/page.tsx
               </Text>
             </InlineCode>
-            <Heading wrap="balance" variant="display-default-l" align="center" marginBottom="16">
+            <Heading
+              wrap="balance"
+              variant="display-default-l"
+              align="center"
+              marginBottom="16"
+            >
               We let designers code and developers design
             </Heading>
             <Button
@@ -247,7 +272,11 @@ export default function Home() {
               arrowIcon
             />
             <Column horizontal="center" paddingTop="64" fillWidth gap="24">
-              <Line maxWidth={4} marginBottom="16" background="neutral-alpha-medium" />
+              <Line
+                maxWidth={4}
+                marginBottom="16"
+                background="neutral-alpha-medium"
+              />
               <AvatarGroup
                 marginBottom="8"
                 reverse
@@ -261,7 +290,12 @@ export default function Home() {
                   },
                 ]}
               />
-              <Heading marginBottom="12" as="h2" align="center" variant="heading-default-l">
+              <Heading
+                marginBottom="12"
+                as="h2"
+                align="center"
+                variant="heading-default-l"
+              >
                 Brought to you by indie creators
                 <br /> behind stellar projects:
               </Heading>
@@ -300,7 +334,13 @@ export default function Home() {
               />
             </Column>
           </Column>
-          <Column fillWidth paddingX="32" gap="12" horizontal="center" position="relative">
+          <Column
+            fillWidth
+            paddingX="32"
+            gap="12"
+            horizontal="center"
+            position="relative"
+          >
             <Heading as="h2" variant="display-default-m">
               Showcase
             </Heading>
@@ -318,9 +358,19 @@ export default function Home() {
               overflow="hidden"
             >
               <Row fill hide="m">
-                <SmartImage src="/images/login.png" alt="Preview image" sizes="560px" />
+                <SmartImage
+                  src="/images/login.png"
+                  alt="Preview image"
+                  sizes="560px"
+                />
               </Row>
-              <Column fillWidth horizontal="center" gap="20" padding="32" position="relative">
+              <Column
+                fillWidth
+                horizontal="center"
+                gap="20"
+                padding="32"
+                position="relative"
+              >
                 <Background
                   mask={{
                     x: 100,
@@ -363,7 +413,12 @@ export default function Home() {
                   />
                 </Column>
                 <Row fillWidth paddingY="24">
-                  <Row onBackground="neutral-weak" fillWidth gap="24" vertical="center">
+                  <Row
+                    onBackground="neutral-weak"
+                    fillWidth
+                    gap="24"
+                    vertical="center"
+                  >
                     <Line />/<Line />
                   </Row>
                 </Row>
@@ -481,7 +536,9 @@ export default function Home() {
                     >
                       <Column gap="4">
                         <Text variant="body-default-m">08 / 27</Text>
-                        <Text variant="body-default-m">1234 5678 1234 5678</Text>
+                        <Text variant="body-default-m">
+                          1234 5678 1234 5678
+                        </Text>
                       </Column>
                       <Icon name="visa" size="xl" />
                     </Row>
@@ -491,7 +548,12 @@ export default function Home() {
             </TiltFx>
           </Row>
           <Column position="relative" fillWidth gap="-1">
-            <Row fillWidth vertical="center" horizontal="space-between" marginBottom="32">
+            <Row
+              fillWidth
+              vertical="center"
+              horizontal="space-between"
+              marginBottom="32"
+            >
               <Heading as="h3" variant="display-default-xs">
                 Fill in your card details
               </Heading>
@@ -659,7 +721,14 @@ export default function Home() {
             }}
           />
           <Column maxWidth={32} gap="-1">
-            <Feedback icon variant="success" vertical="center" radius={undefined} topRadius="l" zIndex={1}>
+            <Feedback
+              icon
+              variant="success"
+              vertical="center"
+              radius={undefined}
+              topRadius="l"
+              zIndex={1}
+            >
               Your profile is public.
             </Feedback>
             <Column
@@ -674,7 +743,9 @@ export default function Home() {
             >
               <MediaUpload
                 border={undefined}
-                emptyState={<Row paddingBottom="80">Drag and drop or click to browse</Row>}
+                emptyState={
+                  <Row paddingBottom="80">Drag and drop or click to browse</Row>
+                }
                 position="absolute"
                 aspectRatio="16 / 9"
                 sizes="560px"
@@ -701,11 +772,17 @@ export default function Home() {
                 <Heading marginTop="24" as="h3" variant="display-default-m">
                   Lorant One
                 </Heading>
-                <Text align="center" onBackground="neutral-weak" marginBottom="24">
+                <Text
+                  align="center"
+                  onBackground="neutral-weak"
+                  marginBottom="24"
+                >
                   165 connections
                 </Text>
                 <SegmentedControl
-                  onToggle={(value) => console.log("SegmentedControl changed", value)}
+                  onToggle={(value) =>
+                    console.log("SegmentedControl changed", value)
+                  }
                   buttons={[
                     {
                       size: "l",
@@ -920,22 +997,38 @@ export default function Home() {
               height: "0.25rem",
             }}
           />
-          <Row position="relative" textVariant="display-default-m" align="center">
+          <Row
+            position="relative"
+            textVariant="display-default-m"
+            align="center"
+          >
             Learn more
           </Row>
         </Row>
         <Row fillWidth overflow="hidden">
-          <Row maxWidth="32" borderTop="neutral-alpha-weak" borderBottom="neutral-medium"></Row>
+          <Row
+            maxWidth="32"
+            borderTop="neutral-alpha-weak"
+            borderBottom="neutral-medium"
+          ></Row>
           <Row fillWidth border="neutral-alpha-weak" mobileDirection="column">
             {links.map((link, index) => (
-              <SmartLink unstyled fillWidth target="_blank" key={link.href} href={link.href}>
+              <SmartLink
+                unstyled
+                fillWidth
+                target="_blank"
+                key={link.href}
+                href={link.href}
+              >
                 <Card
                   fillWidth
                   padding="40"
                   gap="8"
                   direction="column"
                   background={undefined}
-                  borderRight={index < links.length - 1 ? "neutral-alpha-weak" : undefined}
+                  borderRight={
+                    index < links.length - 1 ? "neutral-alpha-weak" : undefined
+                  }
                   border={undefined}
                   radius={undefined}
                 >
@@ -945,14 +1038,22 @@ export default function Home() {
                     </Text>
                     <Icon size="s" name="arrowUpRight" />
                   </Row>
-                  <Text align="center" variant="body-default-s" onBackground="neutral-weak">
+                  <Text
+                    align="center"
+                    variant="body-default-s"
+                    onBackground="neutral-weak"
+                  >
                     {link.description}
                   </Text>
                 </Card>
               </SmartLink>
             ))}
           </Row>
-          <Row maxWidth="32" borderTop="neutral-alpha-weak" borderBottom="neutral-medium"></Row>
+          <Row
+            maxWidth="32"
+            borderTop="neutral-alpha-weak"
+            borderBottom="neutral-medium"
+          ></Row>
         </Row>
         <Row
           position="relative"
@@ -1005,7 +1106,10 @@ export default function Home() {
         onHeightChange={(height) => setFirstDialogHeight(height)}
         footer={
           <>
-            <Button variant="secondary" onClick={() => setIsFirstDialogOpen(false)}>
+            <Button
+              variant="secondary"
+              onClick={() => setIsFirstDialogOpen(false)}
+            >
               Close
             </Button>
           </>
@@ -1019,7 +1123,9 @@ export default function Home() {
             label="2FA"
             description="Enable two factor authentication"
           />
-          <Button onClick={() => setIsSecondDialogOpen(true)}>Change password</Button>
+          <Button onClick={() => setIsSecondDialogOpen(true)}>
+            Change password
+          </Button>
         </Column>
       </Dialog>
       <Dialog
@@ -1031,7 +1137,10 @@ export default function Home() {
         minHeight={firstDialogHeight}
         footer={
           <>
-            <Button variant="secondary" onClick={() => setIsSecondDialogOpen(false)}>
+            <Button
+              variant="secondary"
+              onClick={() => setIsSecondDialogOpen(false)}
+            >
               Close
             </Button>
             <Button onClick={() => setIsSecondDialogOpen(false)}>Save</Button>

--- a/src/once-ui/components/Badge.tsx
+++ b/src/once-ui/components/Badge.tsx
@@ -4,10 +4,11 @@ import React, { forwardRef } from "react";
 import { Arrow, Flex, Icon, SmartLink, Text } from ".";
 
 import styles from "./Badge.module.scss";
+import { IconName } from "../icons";
 
 interface BadgeProps extends React.ComponentProps<typeof Flex> {
   title?: string;
-  icon?: string;
+  icon?: IconName;
   arrow?: boolean;
   children?: React.ReactNode;
   href?: string;
@@ -15,7 +16,10 @@ interface BadgeProps extends React.ComponentProps<typeof Flex> {
 }
 
 const Badge = forwardRef<HTMLDivElement | HTMLAnchorElement, BadgeProps>(
-  ({ title, icon, arrow = true, children, href, effect = true, ...rest }, ref) => {
+  (
+    { title, icon, arrow = true, children, href, effect = true, ...rest },
+    ref
+  ) => {
     const content = (
       <Flex
         id="badge"
@@ -30,7 +34,14 @@ const Badge = forwardRef<HTMLDivElement | HTMLAnchorElement, BadgeProps>(
         shadow="l"
         {...rest}
       >
-        {icon && <Icon className="mr-8" size="s" name={icon} onBackground="brand-medium" />}
+        {icon && (
+          <Icon
+            className="mr-8"
+            size="s"
+            name={icon}
+            onBackground="brand-medium"
+          />
+        )}
         {title && (
           <Text onBackground="brand-strong" variant="label-strong-s">
             {title}
@@ -59,7 +70,7 @@ const Badge = forwardRef<HTMLDivElement | HTMLAnchorElement, BadgeProps>(
     return React.cloneElement(content, {
       ref: ref as React.Ref<HTMLDivElement>,
     });
-  },
+  }
 );
 
 Badge.displayName = "Badge";

--- a/src/once-ui/components/Button.tsx
+++ b/src/once-ui/components/Button.tsx
@@ -6,6 +6,7 @@ import classNames from "classnames";
 
 import { Spinner, Icon, Arrow, Flex } from ".";
 import styles from "./Button.module.scss";
+import { IconName } from "../icons";
 
 interface CommonProps {
   variant?: "primary" | "secondary" | "tertiary" | "danger";
@@ -22,8 +23,8 @@ interface CommonProps {
     | "bottom-left";
   label?: string;
   weight?: "default" | "strong";
-  prefixIcon?: string;
-  suffixIcon?: string;
+  prefixIcon?: IconName;
+  suffixIcon?: IconName;
   loading?: boolean;
   fillWidth?: boolean;
   justifyContent?: "flex-start" | "center" | "flex-end" | "space-between";
@@ -35,8 +36,10 @@ interface CommonProps {
   arrowIcon?: boolean;
 }
 
-export type ButtonProps = CommonProps & React.ButtonHTMLAttributes<HTMLButtonElement>;
-export type AnchorProps = CommonProps & React.AnchorHTMLAttributes<HTMLAnchorElement>;
+export type ButtonProps = CommonProps &
+  React.ButtonHTMLAttributes<HTMLButtonElement>;
+export type AnchorProps = CommonProps &
+  React.AnchorHTMLAttributes<HTMLAnchorElement>;
 
 const Button = forwardRef<HTMLButtonElement, ButtonProps | AnchorProps>(
   (
@@ -59,7 +62,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps | AnchorProps>(
       style,
       ...props
     },
-    ref,
+    ref
   ) => {
     const iconSize = size === "l" ? "s" : size === "m" ? "s" : "xs";
     const radiusSize = size === "s" || size === "m" ? "m" : "l";
@@ -76,8 +79,8 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps | AnchorProps>(
           radius === "none"
             ? "radius-none"
             : radius
-              ? `radius-${radiusSize}-${radius}`
-              : `radius-${radiusSize}`,
+            ? `radius-${radiusSize}-${radius}`
+            : `radius-${radiusSize}`,
           "text-decoration-none",
           "button",
           "cursor-interactive",
@@ -86,7 +89,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps | AnchorProps>(
             ["fit-width"]: !fillWidth,
             ["justify-" + justifyContent]: justifyContent,
           },
-          className,
+          className
         )}
         style={style}
         {...props}
@@ -117,7 +120,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps | AnchorProps>(
         {suffixIcon && <Icon name={suffixIcon} size={iconSize} />}
       </ElementType>
     );
-  },
+  }
 );
 
 Button.displayName = "Button";

--- a/src/once-ui/components/Chip.tsx
+++ b/src/once-ui/components/Chip.tsx
@@ -4,11 +4,12 @@ import React, { ReactNode, MouseEventHandler, forwardRef } from "react";
 import classNames from "classnames";
 import { Text, Icon, IconButton, IconButtonProps, Flex } from ".";
 import styles from "./Chip.module.scss";
+import { IconName } from "../icons";
 
 interface ChipProps extends React.ComponentProps<typeof Flex> {
   label: string;
   selected?: boolean;
-  prefixIcon?: string;
+  prefixIcon?: IconName;
   onRemove?: () => void;
   onClick?: MouseEventHandler<HTMLDivElement>;
   children?: ReactNode;
@@ -29,7 +30,7 @@ const Chip: React.FC<ChipProps> = forwardRef<HTMLDivElement, ChipProps>(
       iconButtonProps = {},
       ...rest
     },
-    ref,
+    ref
   ) => {
     const defaultIconButtonProps: IconButtonProps = {
       icon: "close",
@@ -93,7 +94,7 @@ const Chip: React.FC<ChipProps> = forwardRef<HTMLDivElement, ChipProps>(
         )}
       </Flex>
     );
-  },
+  }
 );
 
 Chip.displayName = "Chip";

--- a/src/once-ui/components/Icon.tsx
+++ b/src/once-ui/components/Icon.tsx
@@ -3,14 +3,14 @@
 import React, { forwardRef, useState, useEffect, ReactNode } from "react";
 import classNames from "classnames";
 import { IconType } from "react-icons";
-import { iconLibrary } from "../icons";
+import { iconLibrary, IconName } from "../icons";
 import { ColorScheme, ColorWeight } from "../types";
 import { Flex, Tooltip } from ".";
 import styles from "./Icon.module.scss";
 import iconStyles from "./IconButton.module.scss";
 
 interface IconProps extends React.ComponentProps<typeof Flex> {
-  name: string;
+  name: IconName;
   onBackground?: `${ColorScheme}-${ColorWeight}`;
   onSolid?: `${ColorScheme}-${ColorWeight}`;
   size?: "xs" | "s" | "m" | "l" | "xl";
@@ -31,7 +31,7 @@ const Icon = forwardRef<HTMLDivElement, IconProps>(
       tooltipPosition = "top",
       ...rest
     },
-    ref,
+    ref
   ) => {
     const IconComponent: IconType | undefined = iconLibrary[name];
 
@@ -42,14 +42,17 @@ const Icon = forwardRef<HTMLDivElement, IconProps>(
 
     if (onBackground && onSolid) {
       console.warn(
-        "You cannot use both 'onBackground' and 'onSolid' props simultaneously. Only one will be applied.",
+        "You cannot use both 'onBackground' and 'onSolid' props simultaneously. Only one will be applied."
       );
     }
 
     let colorClass = "color-inherit";
 
     if (onBackground) {
-      const [scheme, weight] = onBackground.split("-") as [ColorScheme, ColorWeight];
+      const [scheme, weight] = onBackground.split("-") as [
+        ColorScheme,
+        ColorWeight
+      ];
       colorClass = `${scheme}-on-background-${weight}`;
     } else if (onSolid) {
       const [scheme, weight] = onSolid.split("-") as [ColorScheme, ColorWeight];
@@ -89,13 +92,17 @@ const Icon = forwardRef<HTMLDivElement, IconProps>(
       >
         <IconComponent />
         {tooltip && isTooltipVisible && (
-          <Flex position="absolute" zIndex={1} className={iconStyles[tooltipPosition]}>
+          <Flex
+            position="absolute"
+            zIndex={1}
+            className={iconStyles[tooltipPosition]}
+          >
             <Tooltip label={tooltip} />
           </Flex>
         )}
       </Flex>
     );
-  },
+  }
 );
 
 Icon.displayName = "Icon";

--- a/src/once-ui/components/IconButton.tsx
+++ b/src/once-ui/components/IconButton.tsx
@@ -6,9 +6,10 @@ import { Flex, Icon, Tooltip } from ".";
 import buttonStyles from "./Button.module.scss";
 import iconStyles from "./IconButton.module.scss";
 import classNames from "classnames";
+import { IconName } from "../icons";
 
 interface CommonProps {
-  icon?: string;
+  icon?: IconName;
   id?: string;
   size?: "s" | "m" | "l";
   radius?:
@@ -30,7 +31,8 @@ interface CommonProps {
   children?: ReactNode;
 }
 
-export type IconButtonProps = CommonProps & React.ButtonHTMLAttributes<HTMLButtonElement>;
+export type IconButtonProps = CommonProps &
+  React.ButtonHTMLAttributes<HTMLButtonElement>;
 type AnchorProps = CommonProps & React.AnchorHTMLAttributes<HTMLAnchorElement>;
 
 const IconButton = forwardRef<HTMLButtonElement, IconButtonProps | AnchorProps>(
@@ -49,7 +51,7 @@ const IconButton = forwardRef<HTMLButtonElement, IconButtonProps | AnchorProps>(
       style,
       ...props
     },
-    ref,
+    ref
   ) => {
     const [isTooltipVisible, setTooltipVisible] = useState(false);
     const [isHover, setIsHover] = useState(false);
@@ -71,7 +73,11 @@ const IconButton = forwardRef<HTMLButtonElement, IconButtonProps | AnchorProps>(
       <>
         {children ? children : <Icon name={icon} size="s" />}
         {tooltip && isTooltipVisible && (
-          <Flex position="absolute" zIndex={1} className={iconStyles[tooltipPosition]}>
+          <Flex
+            position="absolute"
+            zIndex={1}
+            className={iconStyles[tooltipPosition]}
+          >
             <Tooltip label={tooltip} />
           </Flex>
         )}
@@ -93,12 +99,12 @@ const IconButton = forwardRef<HTMLButtonElement, IconButtonProps | AnchorProps>(
           radius === "none"
             ? "radius-none"
             : radius
-              ? `radius-${radiusSize}-${radius}`
-              : `radius-${radiusSize}`,
+            ? `radius-${radiusSize}-${radius}`
+            : `radius-${radiusSize}`,
           "text-decoration-none",
           "button",
           "cursor-interactive",
-          className,
+          className
         )}
         style={style}
         onMouseEnter={() => setIsHover(true)}
@@ -111,7 +117,7 @@ const IconButton = forwardRef<HTMLButtonElement, IconButtonProps | AnchorProps>(
         </Flex>
       </ElementType>
     );
-  },
+  }
 );
 
 IconButton.displayName = "IconButton";

--- a/src/once-ui/components/SmartLink.tsx
+++ b/src/once-ui/components/SmartLink.tsx
@@ -4,10 +4,11 @@ import React, { forwardRef, ReactNode } from "react";
 import classNames from "classnames";
 import { Icon } from ".";
 import { ElementType } from "./ElementType";
+import { IconName } from "../icons";
 
 interface CommonProps {
-  prefixIcon?: string;
-  suffixIcon?: string;
+  prefixIcon?: IconName;
+  suffixIcon?: IconName;
   fillWidth?: boolean;
   iconSize?: "xs" | "s" | "m" | "l" | "xl";
   selected?: boolean;
@@ -18,7 +19,8 @@ interface CommonProps {
   className?: string;
 }
 
-export type SmartLinkProps = CommonProps & React.AnchorHTMLAttributes<HTMLAnchorElement>;
+export type SmartLinkProps = CommonProps &
+  React.AnchorHTMLAttributes<HTMLAnchorElement>;
 
 const SmartLink = forwardRef<HTMLAnchorElement, SmartLinkProps>(
   (
@@ -35,7 +37,7 @@ const SmartLink = forwardRef<HTMLAnchorElement, SmartLinkProps>(
       children,
       ...props
     },
-    ref,
+    ref
   ) => {
     const content = (
       <>
@@ -54,7 +56,7 @@ const SmartLink = forwardRef<HTMLAnchorElement, SmartLinkProps>(
           "fill-width": fillWidth,
           "fit-width": !fillWidth,
           "px-2 mx-2": !unstyled,
-        },
+        }
       ),
       style: !unstyled
         ? {
@@ -75,7 +77,7 @@ const SmartLink = forwardRef<HTMLAnchorElement, SmartLinkProps>(
         {content}
       </ElementType>
     );
-  },
+  }
 );
 
 SmartLink.displayName = "SmartLink";

--- a/src/once-ui/components/Tag.tsx
+++ b/src/once-ui/components/Tag.tsx
@@ -5,13 +5,22 @@ import classNames from "classnames";
 
 import { Flex, Text, Icon } from ".";
 import styles from "./Tag.module.scss";
+import { IconName } from "../icons";
 
 interface TagProps extends React.ComponentProps<typeof Flex> {
-  variant?: "brand" | "accent" | "warning" | "success" | "danger" | "neutral" | "info" | "gradient";
+  variant?:
+    | "brand"
+    | "accent"
+    | "warning"
+    | "success"
+    | "danger"
+    | "neutral"
+    | "info"
+    | "gradient";
   size?: "s" | "m" | "l";
   label?: string;
-  prefixIcon?: string;
-  suffixIcon?: string;
+  prefixIcon?: IconName;
+  suffixIcon?: IconName;
   children?: ReactNode;
 }
 
@@ -27,7 +36,7 @@ const Tag = forwardRef<HTMLDivElement, TagProps>(
       children,
       ...rest
     },
-    ref,
+    ref
   ) => {
     const paddingSize = size === "s" ? "2" : "4";
 
@@ -40,11 +49,20 @@ const Tag = forwardRef<HTMLDivElement, TagProps>(
         radius="l"
         gap="4"
         ref={ref}
-        className={classNames(styles.tag, styles[variant], styles[size], className)}
+        className={classNames(
+          styles.tag,
+          styles[variant],
+          styles[size],
+          className
+        )}
         {...rest}
       >
         {prefixIcon && <Icon name={prefixIcon} size="xs" />}
-        <Flex style={{ userSelect: "none" }} paddingX={paddingSize} vertical="center">
+        <Flex
+          style={{ userSelect: "none" }}
+          paddingX={paddingSize}
+          vertical="center"
+        >
           <Text as="span" variant="label-default-s">
             {label || children}
           </Text>
@@ -52,7 +70,7 @@ const Tag = forwardRef<HTMLDivElement, TagProps>(
         {suffixIcon && <Icon name={suffixIcon} size="xs" />}
       </Flex>
     );
-  },
+  }
 );
 
 Tag.displayName = "Tag";

--- a/src/once-ui/components/Toast.tsx
+++ b/src/once-ui/components/Toast.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState, forwardRef } from "react";
 import { IconButton, Icon, Flex, Text } from ".";
 import classNames from "classnames";
 import styles from "./Toast.module.scss";
+import { IconName } from "../icons";
 
 interface ToastProps {
   className?: string;
@@ -14,7 +15,7 @@ interface ToastProps {
   children: React.ReactNode;
 }
 
-const iconMap = {
+const iconMap: { [key in ToastProps["variant"]]: IconName } = {
   success: "checkCircle",
   danger: "errorCircle",
 };
@@ -51,7 +52,13 @@ const Toast = forwardRef<HTMLDivElement, ToastProps>(
         })}
       >
         <Flex fillWidth vertical="center" gap="8">
-          {icon && <Icon size="s" onBackground={`${variant}-medium`} name={iconMap[variant]} />}
+          {icon && (
+            <Icon
+              size="s"
+              onBackground={`${variant}-medium`}
+              name={iconMap[variant]}
+            />
+          )}
           <Text variant="body-default-s" style={{ width: "100%" }} as="div">
             {children}
           </Text>
@@ -69,7 +76,7 @@ const Toast = forwardRef<HTMLDivElement, ToastProps>(
         </Flex>
       </Flex>
     );
-  },
+  }
 );
 
 Toast.displayName = "Toast";

--- a/src/once-ui/components/ToggleButton.tsx
+++ b/src/once-ui/components/ToggleButton.tsx
@@ -5,6 +5,7 @@ import classNames from "classnames";
 import { ElementType } from "./ElementType";
 import { Flex, Icon } from ".";
 import styles from "./ToggleButton.module.scss";
+import { IconName } from "../icons";
 
 interface CommonProps {
   label?: ReactNode;
@@ -25,15 +26,16 @@ interface CommonProps {
   fillWidth?: boolean;
   weight?: "default" | "strong";
   truncate?: boolean;
-  prefixIcon?: string;
-  suffixIcon?: string;
+  prefixIcon?: IconName;
+  suffixIcon?: IconName;
   className?: string;
   style?: React.CSSProperties;
   children?: ReactNode;
   href?: string;
 }
 
-export type ToggleButtonProps = CommonProps & React.ButtonHTMLAttributes<HTMLButtonElement>;
+export type ToggleButtonProps = CommonProps &
+  React.ButtonHTMLAttributes<HTMLButtonElement>;
 
 const ToggleButton = forwardRef<HTMLElement, ToggleButtonProps>(
   (
@@ -55,7 +57,7 @@ const ToggleButton = forwardRef<HTMLElement, ToggleButtonProps>(
       href,
       ...props
     },
-    ref,
+    ref
   ) => {
     return (
       <ElementType
@@ -69,8 +71,8 @@ const ToggleButton = forwardRef<HTMLElement, ToggleButtonProps>(
           radius === "none"
             ? "radius-none"
             : radius
-              ? `radius-${size}-${radius}`
-              : `radius-${size}`,
+            ? `radius-${size}-${radius}`
+            : `radius-${size}`,
           "text-decoration-none",
           "button",
           "cursor-interactive",
@@ -79,12 +81,14 @@ const ToggleButton = forwardRef<HTMLElement, ToggleButtonProps>(
             ["fit-width"]: !fillWidth,
             ["justify-" + justifyContent]: justifyContent,
           },
-          className,
+          className
         )}
         style={style}
         {...props}
       >
-        {prefixIcon && <Icon name={prefixIcon} size={size === "l" ? "s" : "xs"} />}
+        {prefixIcon && (
+          <Icon name={prefixIcon} size={size === "l" ? "s" : "xs"} />
+        )}
         {(label || children) && (
           <Flex
             padding={size === "s" ? "2" : "4"}
@@ -95,10 +99,12 @@ const ToggleButton = forwardRef<HTMLElement, ToggleButtonProps>(
             {label || children}
           </Flex>
         )}
-        {suffixIcon && <Icon name={suffixIcon} size={size === "l" ? "m" : "s"} />}
+        {suffixIcon && (
+          <Icon name={suffixIcon} size={size === "l" ? "m" : "s"} />
+        )}
       </ElementType>
     );
-  },
+  }
 );
 
 ToggleButton.displayName = "ToggleButton";

--- a/src/once-ui/components/Tooltip.tsx
+++ b/src/once-ui/components/Tooltip.tsx
@@ -4,11 +4,12 @@ import React, { forwardRef, ReactNode } from "react";
 import classNames from "classnames";
 
 import { Flex, Icon } from ".";
+import { IconName } from "../icons";
 
 type TooltipProps = {
   label: ReactNode;
-  prefixIcon?: string;
-  suffixIcon?: string;
+  prefixIcon?: IconName;
+  suffixIcon?: IconName;
   className?: string;
   style?: React.CSSProperties;
 };
@@ -47,7 +48,7 @@ const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
         {suffixIcon && <Icon name={suffixIcon} size="xs" />}
       </Flex>
     );
-  },
+  }
 );
 
 Tooltip.displayName = "Tooltip";

--- a/src/once-ui/icons.ts
+++ b/src/once-ui/icons.ts
@@ -34,7 +34,7 @@ import { RiVisaLine } from "react-icons/ri";
 
 import { FaDiscord, FaGithub, FaGoogle } from "react-icons/fa6";
 
-export const iconLibrary: Record<string, IconType> = {
+export const iconLibrary = {
   chevronUp: HiChevronUp,
   chevronDown: HiChevronDown,
   chevronRight: HiChevronRight,
@@ -67,3 +67,6 @@ export const iconLibrary: Record<string, IconType> = {
   security: HiOutlineShieldCheck,
   sparkle: HiOutlineSparkles,
 };
+
+export type IconLibrary = typeof iconLibrary;
+export type IconName = keyof IconLibrary;


### PR DESCRIPTION
## Changes
- Added `IconLibrary` and `IconName` types for better type safety for icon-library.
- Ensured all references to `iconLibrary` use `IconName` for proper autocompletion.
- Simplified the structure by replacing `Record<string, IconType>` with `typeof iconLibrary`.

## Why?
- Prevents accidental usage of incorrect icon names.
- Improves DX (Developer Experience) with autocompletion.
- Enhances maintainability for future icon updates.

## Screenshots
Before:
![Screenshot From 2025-03-15 22-29-48](https://github.com/user-attachments/assets/afe7e745-c7cf-43af-8966-c708347b2641)

After:
![Screenshot From 2025-03-15 22-29-20](https://github.com/user-attachments/assets/76f13607-9bef-473f-bfe3-37e2a04a2e85)

## How to Test
- Run `npm run build` or `yarn build` or `pnpm build` to ensure no TypeScript errors.
- Check UI components using `iconLibrary` to confirm proper typings.
