### PR TITLE
feat: DropdownWrapper can ignore clicks inside the dropdown.

### DIFF
--- a/src/once-ui/components/DropdownWrapper.tsx
+++ b/src/once-ui/components/DropdownWrapper.tsx
@@ -32,6 +32,7 @@ export interface DropdownWrapperProps {
   style?: React.CSSProperties;
   className?: string;
   onSelect?: (value: string) => void;
+  ignoreClickInside?: boolean;
   isOpen?: boolean;
   onOpenChange?: (isOpen: boolean) => void;
 }
@@ -44,6 +45,7 @@ const DropdownWrapper = forwardRef<HTMLDivElement, DropdownWrapperProps>(
       selectedOption,
       minHeight,
       onSelect,
+      ignoreClickInside = false,
       isOpen: controlledIsOpen,
       onOpenChange,
       minWidth,
@@ -154,7 +156,11 @@ const DropdownWrapper = forwardRef<HTMLDivElement, DropdownWrapperProps>(
         className={className}
         position="relative"
         ref={wrapperRef}
-        onClick={() => handleOpenChange(!isOpen)}
+        onClick={() => {
+            if (!ignoreClickInside) {
+                handleOpenChange(!isOpen);
+            }
+        }}
         onKeyDown={(e) => {
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();


### PR DESCRIPTION
- Added ignoreClickInside (bool) argument to DropdownWrapperProps with a default value of true.
- Added condition to only close the DropdownWrapper on a click inside the dropdown if ignoreClickInside is true.

Differentiating between internal clicks (i.e. clicks on the content of the dropdown) and external clicks (outside the dropdown) will allow for a wide range of customisation and complex scenarios. This should support scenarios like multi-select dropdowns and date-range inputs. 

This change introduces a non-breaking API change.