### PR TITLE
Feat: Added component: DateRangeInput

### DIFF
--- a/src/once-ui/components/DateRangeInput.tsx
+++ b/src/once-ui/components/DateRangeInput.tsx
@@ -3,9 +3,10 @@
 import React, {useState, useCallback, useEffect} from "react";
 import {Input, DropdownWrapper, Flex, DateRange, DateRangePicker, Row} from ".";
 
-interface DateRangeInputProps extends Omit<React.ComponentProps<typeof Input>, "onChange" | "value"> {
+interface DateRangeInputProps extends Omit<React.ComponentProps<typeof Input>, "onChange" | "value" | "label"> {
     id: string;
-    label: string;
+    startLabel: string;
+    endLabel: string;
     value?: DateRange;
     onChange?: (range: DateRange) => void;
     minHeight?: number;
@@ -32,7 +33,8 @@ const formatDateRange = (range: DateRange): LocalizedDateRange => {
 
 export const DateRangeInput: React.FC<DateRangeInputProps> = ({
                                                                   id,
-                                                                  label,
+                                                                  startLabel = "Start",
+                                                                  endLabel = "End",
                                                                   value,
                                                                   onChange,
                                                                   error,
@@ -74,13 +76,12 @@ export const DateRangeInput: React.FC<DateRangeInputProps> = ({
                 }}
                 radius={"left"}
                 id={id}
-                label={label}
+                label={startLabel}
                 value={inputValue.startDate ?? ""}
                 error={error}
                 readOnly
                 onClick={handleInputClick}
-                {...rest}
-            />
+                {...rest}/>
             <Input
                 className="cursor-interactive"
                 style={{
@@ -88,7 +89,7 @@ export const DateRangeInput: React.FC<DateRangeInputProps> = ({
                 }}
                 radius={"right"}
                 id={id}
-                label={label}
+                label={endLabel}
                 value={inputValue.endDate ?? ""}
                 error={error}
                 readOnly

--- a/src/once-ui/components/DateRangeInput.tsx
+++ b/src/once-ui/components/DateRangeInput.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import React, {useState, useCallback, useEffect} from "react";
+import {Input, DropdownWrapper, Flex, DateRange, DateRangePicker, Row} from ".";
+
+interface DateRangeInputProps extends Omit<React.ComponentProps<typeof Input>, "onChange" | "value"> {
+    id: string;
+    label: string;
+    value?: DateRange;
+    onChange?: (range: DateRange) => void;
+    minHeight?: number;
+    className?: string;
+    style?: React.CSSProperties;
+}
+
+interface LocalizedDateRange {
+    startDate: string | null;
+    endDate: string | null;
+}
+
+const formatDateRange = (range: DateRange): LocalizedDateRange => {
+    const options: Intl.DateTimeFormatOptions = {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+    };
+    return {
+        startDate: range.startDate?.toLocaleDateString("en-US", options) || null,
+        endDate: range.endDate?.toLocaleDateString("en-US", options) || null,
+    };
+};
+
+export const DateRangeInput: React.FC<DateRangeInputProps> = ({
+                                                                  id,
+                                                                  label,
+                                                                  value,
+                                                                  onChange,
+                                                                  error,
+                                                                  minHeight,
+                                                                  className,
+                                                                  style,
+                                                                  ...rest
+                                                              }) => {
+    const [isOpen, setIsOpen] = useState(false);
+    const [inputValue, setInputValue] = useState(value ? formatDateRange(value) : {startDate: "", endDate: ""});
+    useEffect(() => {
+        if (value) {
+            setInputValue(formatDateRange(value));
+        }
+    }, [value]);
+
+    const handleDateChange = useCallback(
+        (range: DateRange) => {
+            setInputValue(formatDateRange(range));
+            onChange?.(range);
+            if (range.endDate != undefined) {
+                setIsOpen(false);
+            }
+        },
+        [onChange],
+    );
+
+    const handleInputClick = useCallback(() => {
+        setIsOpen(true);
+    }, []);
+
+    const trigger = (
+        <Row fillWidth horizontal="center" gap="-1">
+            <Input
+                className="cursor-interactive"
+
+                style={{
+                    textOverflow: "ellipsis",
+                }}
+                radius={"left"}
+                id={id}
+                label={label}
+                value={inputValue.startDate ?? ""}
+                error={error}
+                readOnly
+                onClick={handleInputClick}
+                {...rest}
+            />
+            <Input
+                className="cursor-interactive"
+                style={{
+                    textOverflow: "ellipsis",
+                }}
+                radius={"right"}
+                id={id}
+                label={label}
+                value={inputValue.endDate ?? ""}
+                error={error}
+                readOnly
+                onClick={handleInputClick}
+                {...rest}
+            />
+        </Row>
+    );
+
+    const dropdown = (
+        <Flex padding="20" center={true}>
+            <DateRangePicker value={value} onChange={handleDateChange}/>
+        </Flex>
+    );
+
+    return (
+        <DropdownWrapper
+            fillWidth
+            trigger={trigger}
+            minHeight={minHeight}
+            dropdown={dropdown}
+            isOpen={isOpen}
+            closeAfterClick={false}
+            className={className}
+            style={{...style}}
+            onOpenChange={
+                setIsOpen
+            }
+        />
+    );
+};

--- a/src/once-ui/components/index.ts
+++ b/src/once-ui/components/index.ts
@@ -14,6 +14,7 @@ export * from "./ColorInput";
 export * from "./CompareImage";
 export * from "./DateInput";
 export * from "./DatePicker";
+export * from "./DateRangeInput";
 export * from "./DateRangePicker";
 export * from "./Dialog";
 export * from "./Dropdown";


### PR DESCRIPTION
**New component: DateRangeInput**
DateRangeInput provides similar behaviour to the DateInput component for date ranges, displaying a DateRangePicker in a DropdownWrapper on click of an Input box.

While it _can_ work uncontrolled, it works best with state controlled by a parent component via the value & onChange props (although I can improve the uncontrolled behaviour if that is desired?)

**Usage:**
```typescript
// Import
import { DateRangeInput, DateRange } from "@/once-ui/components";

// State
const [selectedRange, setSelectedRange] = useState<DateRange>();

// Use component
<DateRangeInput 
    id={"daterangepicker"} 
    value={selectedRange} 
    onChange={setSelectedRange} 
    startLabel={"Check in"} 
    endLabel={"Check out"} 
/>
``` 