### PR TITLE
fix: update URL construction in Meta component

### DIFF
--- a/src/once-ui/modules/seo/Meta.tsx
+++ b/src/once-ui/modules/seo/Meta.tsx
@@ -28,12 +28,13 @@ export function generateMetadata({
   const normalizedPath = path.startsWith("/") ? path : `/${path}`;
 
   const ogImage = image
-    ? `${normalizedBaseURL}${image.startsWith("/") ? image : `/${image}`}`
-    : `${normalizedBaseURL}/og?title=${encodeURIComponent(title)}`;
+    ? `${image.startsWith("/") ? image : `/${image}`}`
+    : `/og?title=${encodeURIComponent(title)}`;
 
-  const url = `${normalizedBaseURL}${normalizedPath}`;
+  const url = `${normalizedPath}`;
 
   return {
+    metadataBase: new URL(normalizedBaseURL.startsWith('https://') ? normalizedBaseURL : `https://${normalizedBaseURL}`),
     title,
     description,
     openGraph: {


### PR DESCRIPTION
Fixed a bug with loading Open Graph (and Twitter) images due to a broken link. 

- Before fix:
![](https://github.com/user-attachments/assets/477ef914-eb97-412a-b1b3-746ca4af34a1)
![](https://github.com/user-attachments/assets/5582449a-0a00-4618-8479-397db2e07bd8)
- After fix:
![](https://github.com/user-attachments/assets/9ae6d3e7-bc83-4853-afbf-068336eaee0d)
![](https://github.com/user-attachments/assets/147b56f4-eaf8-47e8-a7b0-654a1944a50e)


Added missing `metadataBase` parameter.