### PR TITLE
fix: DropdownWrapper is not displayed if it is inside RevealFx

### DIFF
--- a/src/once-ui/components/RevealFx.module.scss
+++ b/src/once-ui/components/RevealFx.module.scss
@@ -1,9 +1,9 @@
 .revealFx {
-    mask-image: linear-gradient(to right, black 0%, black 25%, transparent 50%);
     mask-size: 300% 100%;
     transition: all ease-in-out;
   
     &.hidden {
+      mask-image: linear-gradient(to right, black 0%, black 25%, transparent 50%);
       mask-position: 100% 0;
       filter: blur(0.5rem);
     }


### PR DESCRIPTION
Fixed bug with “invisible” `DropdownWrapper` being in `RevealFx`. #42 

Problem: `mask-image` parameter was active all the time, thus limiting the displayed space.

Solution: moving the parameter to the “hidden” sub-class.

After fix:
https://github.com/user-attachments/assets/f27ad91b-7c35-4b65-91e2-e633489fea81

